### PR TITLE
Person is active 1.0

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,7 +92,7 @@ class ApplicationController < ActionController::Base
 
     # Default SolrRuby params
     @query = params[:q] || "*:*" # Lucene syntax for "find everything"
-    @filter = filter
+    @filter = params[:filter] || filter
     @sort = params[:sort] || "year"
     @order = params[:order] || "descending"
     @page = params[:page] || 0

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -8,7 +8,7 @@ class PeopleController < ApplicationController
     build :index, :new, :create, :show, :edit, :update, :destroy
 
     publish :xml, :json, :yaml, :attributes => [
-      :id, :name, :first_name, :middle_name, :last_name, :prefix, :suffix, :phone, :email, :im, :office_address_line_one, :office_address_line_two, :office_city, :office_state, :office_zip, :research_focus,
+      :id, :name, :first_name, :middle_name, :last_name, :prefix, :suffix, :phone, :email, :im, :office_address_line_one, :office_address_line_two, :office_city, :office_state, :office_zip, :research_focus, :active,
        {:name_strings => [:id, :name]},
        {:groups => [:id, :name]},
        {:contributorships => [:work_id]}

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -25,12 +25,12 @@ class PublicationsController < ApplicationController
     before :index do
       # find first letter of publication name (in uppercase, for paging mechanism)
       @a_to_z = Publication.letters.collect { |d| d.letter.upcase }
-      
+      default_page = @a_to_z.find_index{|item| item > " "} #prevents returning everything when the name has a value of whitespace
       if params[:q]
         query = params[:q]
         @current_objects = current_objects
       else
-        @page = params[:page] || @a_to_z[0]
+        @page = params[:page] || @a_to_z[default_page] 
         @current_objects = Publication.find(
           :all,
           :conditions => ["publications.id = authority_id and upper(name) like ?", "#{@page}%"],

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -25,7 +25,7 @@ class PublicationsController < ApplicationController
     before :index do
       # find first letter of publication name (in uppercase, for paging mechanism)
       @a_to_z = Publication.letters.collect { |d| d.letter.upcase }
-      default_page = @a_to_z.find_index{|item| item > " "} #prevents returning everything when the name has a value of whitespace
+      default_page = @a_to_z.find_index{|i| i > " "} #prevent returning all every title when the name has a value of whitespace
       if params[:q]
         query = params[:q]
         @current_objects = current_objects

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -104,6 +104,10 @@ class WorksController < ApplicationController
     else
       logger.debug("\n\n===Works: #{@current_object.inspect}")
       # Default BibApp search method - ApplicationController
+
+      #Solr filter query for active people
+      params[:filter] = []
+      params[:filter] << "person_active:true"
       search(params)
     end
   end

--- a/app/models/index.rb
+++ b/app/models/index.rb
@@ -58,6 +58,9 @@ class Index
     :person_id => Proc.new{|record| record.people.collect{|p| p.id}},
     :people_data => Proc.new{|record| record.people.collect{|p| p.to_solr_data}},
     
+    #Person's active status in separate field for filtering
+    :person_active => Proc.new{|record| record.people.collect{|p| p.person_active}},
+    
     # Groups
     :groups => Proc.new{|record| record.people.collect{|p| p.groups.collect{|g| g.name}}.uniq.flatten},
     :group_id => Proc.new{|record| record.people.collect{|p| p.groups.collect{|g| g.id}}.uniq.flatten},

--- a/app/models/index_observer.rb
+++ b/app/models/index_observer.rb
@@ -54,7 +54,7 @@ class IndexObserver < ActiveRecord::Observer
 
     #Person: only update index if name or machine_name changed
     when Person
-      return true if record.first_name_changed? or record.last_name_changed? or record.machine_name_changed?
+      return true if record.first_name_changed? or record.last_name_changed? or record.machine_name_changed? or record.active_changed? or record.research_focus_changed?
     
     #Group: only update index if name or machine_name changed
     when Group

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -238,6 +238,18 @@ class Person < ActiveRecord::Base
     gids.join(",")
   end
   
+  #Is the person active? Any blanks will be interpreted as false.
+  def person_active
+    self.active?.to_s   
+  end
+  
+  #A person's research focus.
+  #You get stack overflow without the dump method, I assume
+  #due to the new line or quote characters in the text
+  def person_research_focus
+    self.research_focus.dump
+  end
+  
   # Convert object into semi-structured data to be stored in Solr
   def to_solr_data
     "#{last_name}||#{id}||#{image_url}||#{group_ids}"

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -322,7 +322,7 @@ class Person < ActiveRecord::Base
     end
     
     #Parse Solr data (produced by to_solr_data)
-    # return Person last_name, ID, and Image URL
+    # return Person last_name, ID, Image URL, Active status, and research_focus
     def parse_solr_data(person_data)
       data = person_data.split("||")
       last_name = data[0]
@@ -335,7 +335,11 @@ class Person < ActiveRecord::Base
         group_ids = []
       end
       
-      return last_name, id, image_url, group_ids
+
+      is_active = data[4]
+      research_focus = data[5]
+      
+      return last_name, id, image_url, group_ids, is_active, research_focus
     end
 
     def sort_by_most_recent_work(array_of_people)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -237,7 +237,19 @@ class Person < ActiveRecord::Base
     end
     gids.join(",")
   end
+
+  #KUMC.JTS Is the person active? Any blanks will be interpreted as false.
+  def person_active
+    self.active?.to_s   
+  end
   
+  #KUMC.JTS A person's research focus.
+  #You get stack overflow without the dump method, I assume
+  #due to the new line or quote characters in the text
+  def person_research_focus
+    self.research_focus.dump
+  end  
+
   # Convert object into semi-structured data to be stored in Solr
   def to_solr_data
     "#{last_name}||#{id}||#{image_url}||#{group_ids}"

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -300,6 +300,17 @@ class Person < ActiveRecord::Base
 
   end
 
+  #called by after_save callback
+  # @TODO Find bad dates, e.g. 0001-01-01, and replace them.
+  def update_memberships_end_dates
+    #Update memberships when person becomes inactive
+    if self.active_change == [true,false]
+      self.logger.info("#{self.changes}")
+      self.memberships.update_all({:end_date => Time.now}, ['end_date IS NULL'])
+    end
+  end
+
+
   class << self
     # return the first letter of each name, ordered alphabetically
     def letters

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -252,7 +252,7 @@ class Person < ActiveRecord::Base
   
   # Convert object into semi-structured data to be stored in Solr
   def to_solr_data
-    "#{last_name}||#{id}||#{image_url}||#{group_ids}"
+    "#{last_name}||#{id}||#{image_url}||#{group_ids}||#{person_active}||#{person_research_focus}"
   end
   
   def solr_filter

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -237,19 +237,7 @@ class Person < ActiveRecord::Base
     end
     gids.join(",")
   end
-
-  #KUMC.JTS Is the person active? Any blanks will be interpreted as false.
-  def person_active
-    self.active?.to_s   
-  end
   
-  #KUMC.JTS A person's research focus.
-  #You get stack overflow without the dump method, I assume
-  #due to the new line or quote characters in the text
-  def person_research_focus
-    self.research_focus.dump
-  end  
-
   # Convert object into semi-structured data to be stored in Solr
   def to_solr_data
     "#{last_name}||#{id}||#{image_url}||#{group_ids}"

--- a/app/models/person_observer.rb
+++ b/app/models/person_observer.rb
@@ -2,7 +2,9 @@ class PersonObserver < ActiveRecord::Observer
  
   #Called after Person is created or updated
   def after_save(person)
-    #Update machine_name as necesary
+    #Update memberships if person becomes inactive
+    person.update_memberships_end_dates 
+    #Update machine_name as necessary
     person.update_machine_name
   end
     

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -36,6 +36,9 @@
       %div
         %label="Postal Address"
         = form.text_area :postal_address, :class => "smallbox"
+      %div
+        %label="Active?"
+        = form.check_box :active, :class => "checkbox"
     %div
       %label.lar="Research Focus"
       = form.text_area :research_focus

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -22,6 +22,9 @@
 
     %div#image.span-4
       =image_tag(@person.image_url, :class => "person-image", :size => "125x166")
+      / ### Hide email for inactive people ###
+      - if @person.active?
+        =mail_to(@person.email, "Email", :replace_at => "_at_", :replace_dot => "_dot_", :class => "email")      
 
     %div.span-10
       - if @person.groups.empty?
@@ -29,8 +32,8 @@
       - else
         %h3.heading Groups
         = render :partial => 'shared/group_list'
-
-    - if @person.research_focus.strip.length > 0
+      / ### Hide research focus for inactive people ###
+    - if @person.active? and @person.research_focus.strip.length > 0
       %div#research-focus.span-14
         %h3.heading Research Focus
         %p=@person.research_focus

--- a/app/views/publications/index.html.haml
+++ b/app/views/publications/index.html.haml
@@ -14,7 +14,7 @@
   %div.span-22.prepend-1
     %h2="Publications"
     
-    = render :partial => "shared/alpha_pagination"
+    = render :partial => "shared/alpha_pagination", :locals => {:numbers => true}
 
     %table#publications
       %tr
@@ -34,4 +34,4 @@
 
     %br/
     %br/
-    = render :partial => "shared/alpha_pagination"
+    = render :partial => "shared/alpha_pagination", :locals => {:numbers => true}

--- a/app/views/shared/_alpha_pagination.html.haml
+++ b/app/views/shared/_alpha_pagination.html.haml
@@ -1,5 +1,16 @@
 %ol#alpha-nav.pagination
   - path ||= nil
+  -# @TODO: make this DRY and move it into application_helper.rb
+  - numbers ||= nil
+  - if numbers
+    - ('0'..'9').each do |letter|
+      - current = false
+      - if letter == @page
+        - current = true
+        = letter_link_for(@a_to_z, letter, current, :path => path)
+      - else
+        = letter_link_for(@a_to_z, letter, current, :path => path)     
+      
   - ('A'..'Z').each do |letter|
     - current = false
     - if letter == @page
@@ -7,3 +18,5 @@
       = letter_link_for(@a_to_z, letter, current, :path => path)
     - else
       = letter_link_for(@a_to_z, letter, current, :path => path)
+        
+ 

--- a/app/views/shared/_not_found.html.haml
+++ b/app/views/shared/_not_found.html.haml
@@ -7,8 +7,9 @@
     %h2 Error 404: The page cannot be found
 
     - if controller.controller_name == "people" || controller.controller_name == "groups"
-      %h2 You may have followed a link to a #{controller.controller_name.singularize} no longer
-          at #{$UNIVERSITY_SHORT_NAME}.
+      %h2
+        You may have followed a link to a #{controller.controller_name.singularize} no 
+        longer at #{$UNIVERSITY_SHORT_NAME}.
         
     %p Did you try searching? Enter a keyword(s) in the search field above.
     

--- a/app/views/shared/_not_found.html.haml
+++ b/app/views/shared/_not_found.html.haml
@@ -5,7 +5,12 @@
 %div.span-24
   %div.span-22.prepend-1
     %h2 Error 404: The page cannot be found
-    %p Did you try searching? Enter a keyword(s) in the search field above. Or, try one of the links below.
+
+    - if controller.controller_name == "people" || controller.controller_name == "groups"
+      %h2 You may have followed a link to a #{controller.controller_name.singularize} no longer
+          at #{$UNIVERSITY_SHORT_NAME}.
+        
+    %p Did you try searching? Enter a keyword(s) in the search field above.
     
 %div#facets.span-24{:style => "margin-top:2em;"}
   / People

--- a/app/views/shared/_people.html.haml
+++ b/app/views/shared/_people.html.haml
@@ -12,7 +12,11 @@
     - counter = 0
 
     - people.each do |p|
-      - last_name, id, image_url, group_ids = Person.parse_solr_data(p.name)
+      - person = Person.parse_solr_data(p.name)
+      - last_name, id, image_url, group_ids, active, research_focus = Person.parse_solr_data(p.name)
+      - if active=="false"
+        - next
+
       - if controller.controller_name == "groups" and !group_ids.include?(@group.id)
         - next
       - if count and counter >= count

--- a/app/views/shared/_people.html.haml
+++ b/app/views/shared/_people.html.haml
@@ -14,7 +14,8 @@
     - people.each do |p|
       - person = Person.parse_solr_data(p.name)
       - last_name, id, image_url, group_ids, active, research_focus = Person.parse_solr_data(p.name)
-      - if active=="false"
+
+      - if active.empty? or active == "false"
         - next
 
       - if controller.controller_name == "groups" and !group_ids.include?(@group.id)

--- a/public/stylesheets/blueprint/bibapp.css
+++ b/public/stylesheets/blueprint/bibapp.css
@@ -440,7 +440,6 @@ div.auto_complete ul strong.highlight {
 }
 .pagination a {
   padding: 2px 5px 2px 5px;
-  margin: 2px;
   border: 1px solid #aaaadd;
   text-decoration: none;
   color: #000099;

--- a/vendor/bibapp-solr/conf/schema.xml
+++ b/vendor/bibapp-solr/conf/schema.xml
@@ -269,6 +269,7 @@
  <!-- authors are a synonym for name_strings -->
  <field name="authors" type="text" indexed="true" stored="true" multiValued="true"/>
  <field name="people" type="text" indexed="true" stored="true" multiValued="true"/>
+ <field name="person_active" type="boolean" indexed="true" stored="true" multiValued="true"/>
  <field name="groups" type="text" indexed="true" stored="true" multiValued="true"/>
  <field name="publication" type="text" indexed="true" stored="true"/>
  <field name="publisher" type="text" indexed="true" stored="true"/>


### PR DESCRIPTION
I'd love to get your thoughts on these changes.
We needed a better way to handle faculty who leave. Our Public Affairs colleagues only want to show "who's here right now", but I cringe at the thought of just deleting people and leaving a 404 error behind whether they've died or left.
To that end, my primary goal was just expose the "field" in the person/edit form and use that attribute to close their Group memberships and filter them out of the shared/_people view, so they're not prominently displayed but you can still find the Person record through a search or, for now anyway, in the People list. 
There are also some unrelated changes for listing Publications.

Jason
