### PR TITLE
Fix group list item links

### DIFF
--- a/app/views/shared/_group_list_item.html.haml
+++ b/app/views/shared/_group_list_item.html.haml
@@ -3,7 +3,9 @@
   %li.parent{:style=>"list-style:none;"}
     %strong=link_to m.group.name, group_path(m.group)
     - if m.title
-      %span=" &ndash; <em>#{m.title}</em>"
+      %span
+        &ndash; 
+        %em=m.title
 
     - unless m.group.children.empty?
       %ul.children


### PR DESCRIPTION
In Rails 3, Membership titles were displaying HTML entities and <em> tags.
