### PR TITLE
Make person active

### DIFF
--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -36,6 +36,10 @@
       %div
         %label="Postal Address"
         = form.text_area :postal_address, :class => "smallbox"
+      -if state == "edit"
+        %div
+          %label="Active?"          
+          = form.check_box :active, :class => "checkbox"
     %div
       %label.lar="Research Focus"
       = form.text_area :research_focus

--- a/app/views/people/edit.html.haml
+++ b/app/views/people/edit.html.haml
@@ -16,4 +16,4 @@
 
     = render :partial => "shared/local_nav", :locals => {:object => "person", :state => "edit"}
     
-    = render :partial => 'form'
+    = render :partial => 'form', :locals => {:object => "person", :state => "edit"}

--- a/app/views/people/new.html.haml
+++ b/app/views/people/new.html.haml
@@ -12,7 +12,7 @@
       %p
         = text_field_tag :q, params[:q]
         = submit_tag "Search"
-        ="&nbsp;Ex: Smith, John OR Smith, J"
+        = " Ex: Smith, John OR Smith, J"
 
     - if @ldap_results
       %fieldset
@@ -35,4 +35,4 @@
         %p{:style => "color:red;"}="Search failed: #{@fail_message}."
 
 
-    = render :partial => 'form'
+    = render :partial => 'form', :locals => {:object => "person", :state => "new"}


### PR DESCRIPTION
The empty Active? checkbox still displays on people/new, but the model is going to set the person as active on before_create. Using the same approach as the Admin local-nav and only displaying the checkbox on people/edit seemed to be the most straightforward (and laziest) solution.
Please review when you get a chance.

Jason
