### PR TITLE
Typo in setting default SOLR_STOP_PORT

### DIFF
--- a/config/initializers/solr.rb
+++ b/config/initializers/solr.rb
@@ -35,7 +35,7 @@ SOLR_PORT = "8983" unless defined? SOLR_PORT
 # Port used to send "stop" command to Jetty in order to shutdown Solr nicely
 # (This SOLR_STOP_PORT variable is used by /lib/tasks/solr.rake when stopping Solr)
 SOLR_STOP_PORT = SOLR_SETTINGS['stop_port'] if SOLR_SETTINGS and SOLR_SETTINGS['stop_port']
-SOLR_STOP_PORT = "8079" unless defined? SOLR_STOP_PORT
+SOLR_STOP_PORT = "8097" unless defined? SOLR_STOP_PORT
 
 # Build our Solr URL (used by Solr Connection below)
 SOLR_URL = "http://localhost:#{SOLR_PORT}/solr" unless defined? SOLR_URL


### PR DESCRIPTION
Typo in setting default SOLR_STOP_PORT in

config/initializers/solr.rb
SOLR_STOP_PORT = SOLR_SETTINGS['stop_port'] if SOLR_SETTINGS and SOLR_SETTINGS['stop_port']
SOLR_STOP_PORT = "8079" unless defined? SOLR_STOP_PORT

Was 8079 should be 8097 corresponding to the settings in 

config/solr.yml.example
production:
  port: 8983
  stop_port: 8097
