### PR TITLE
use 127.0.0.1 instead of localhost with Solr

### DIFF
--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -88,7 +88,7 @@ class Publisher < PubCommon
     # First check that solr is running
     # We need it to be in order for the new publishers to be indexed
     begin
-      n = Net::HTTP.new('localhost', SOLR_PORT)
+      n = Net::HTTP.new('127.0.0.1', SOLR_PORT)
       n.request_head('/').value
 
     rescue Errno::ECONNREFUSED, Errno::EBADF, Errno::ENETUNREACH #not responding

--- a/config/initializers/solr.rb
+++ b/config/initializers/solr.rb
@@ -38,7 +38,7 @@ SOLR_STOP_PORT = SOLR_SETTINGS['stop_port'] if SOLR_SETTINGS and SOLR_SETTINGS['
 SOLR_STOP_PORT = "8097" unless defined? SOLR_STOP_PORT
 
 # Build our Solr URL (used by Solr Connection below)
-SOLR_URL = "http://localhost:#{SOLR_PORT}/solr" unless defined? SOLR_URL
+SOLR_URL = "http://127.0.0.1:#{SOLR_PORT}/solr" unless defined? SOLR_URL
 
 # Solr Connection (used by /app/models/index.rb)
 SOLRCONN = Solr::Connection.new(SOLR_URL)

--- a/lib/tasks/solr.rake
+++ b/lib/tasks/solr.rake
@@ -14,7 +14,7 @@ namespace :solr do
   desc 'Starts Solr. Options accepted: RAILS_ENV=your_env, PORT=XX. Defaults to development if none.'
   task :start => :environment do
     begin
-      n = Net::HTTP.new('localhost', SOLR_PORT)
+      n = Net::HTTP.new('127.0.0.1', SOLR_PORT)
       n.request_head('/').value
 
     rescue Net::HTTPServerException #responding


### PR DESCRIPTION
On SuSe Linux there are problems with Solr and the use of 'localhost', works fine with 127.0.0.1. This is a known issue. I encountered it the first time with DSpace and Solr. Replaced localhost with 127.0.0.1 in
app/models/publisher.rb
config/initializers/solr.rb
lib/tasks/solr.rake

app/models/publisher.rb
config/initializers/solr.rb
lib/tasks/solr.rake
