### PR TITLE
 Replaced SQL #order with #sort. Order treats 'J' and 'j' as two differe...

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -214,7 +214,7 @@ class User < ActiveRecord::Base
 
   # return the first letter of each email, ordered alphabetically
   def self.letters
-    self.select('DISTINCT SUBSTR(email, 1, 1) AS letter').order('letter').collect { |x| x.letter.upcase }.uniq
+    self.select('DISTINCT SUBSTR(email, 1, 1) AS letter').collect { |x| x.letter.upcase }.uniq.sort
   end
 
 end


### PR DESCRIPTION
...nt characters where upper set precedes lower set. SQL syntax to alter the case or case-sensitivity appears to differ among databases.
Was failing test == [A, B, F, J] because #order returns [J, a, b, f, j]
